### PR TITLE
Add Tabulator examples to results page

### DIFF
--- a/results.md
+++ b/results.md
@@ -157,7 +157,7 @@ Coming soon!
 
 ## Juniors
 
-Not published, please contact for details. 
+Not published, please contact for details.
 
 # 2018
 
@@ -179,5 +179,18 @@ Not published, please contact for details.
 	var results2019Run = new Tabulator(matches[0], {
 		height:400,
 		layout:"fitColumns",
+	});
+
+	var results2019Walk = new Tabulator(matches[1], {
+		height:400,
+		layout:"fitColumns",
+		columns:[
+			{field:"place", title:"Place"},
+			{field:"bib", title:"Bib"},
+			{field:"time", title:"Time"},
+			{field:"runner", title:"Runner"},
+			{field:"gender", title:"Gender"},
+			{field:"course", title:"Course"},
+		]
 	});
 </script>

--- a/results.md
+++ b/results.md
@@ -172,3 +172,12 @@ Not published, please contact for details.
 
 <link href="https://unpkg.com/tabulator-tables@4.5.3/dist/css/bulma/tabulator_bulma.min.css" rel="stylesheet">
 <script type="text/javascript" src="https://unpkg.com/tabulator-tables@4.5.3/dist/js/tabulator.min.js"></script>
+
+<script type="text/javascript">
+	var matches = document.querySelectorAll("table");
+
+	var results2019Run = new Tabulator(matches[0], {
+		height:400,
+		layout:"fitColumns",
+	});
+</script>

--- a/results.md
+++ b/results.md
@@ -168,3 +168,7 @@ Not published, please contact for details.
 ## Juniors
 
 ![Results 2018 Juniors](/images/2018_Results_Juniors.jpg)
+
+
+<link href="https://unpkg.com/tabulator-tables@4.5.3/dist/css/bulma/tabulator_bulma.min.css" rel="stylesheet">
+<script type="text/javascript" src="https://unpkg.com/tabulator-tables@4.5.3/dist/js/tabulator.min.js"></script>


### PR DESCRIPTION
This PR converts two of the tables on the page into Tabulators.

The `querySelector` function is used to lookup all the tables on the page *(because you are using markdown there is no way to set unique identifiers on the table so i am doing it based on position in the array of all table elements)*

The first table simply uses the table headers to create the columns for the table

The second example explicitly sets the columns in the column definition object, this way you can customise the functionality of each column if needed

The `<link>` tag pulls in the CSS which styles the table, i have chosen the built in bulma theme as it was the closest match to your site. Feel free to have a look at the [Theme Examples](http://tabulator.info/examples/4.5#theming) to pick a different built in theme.

Any questions, drop me a message

Cheers

Oli :)

